### PR TITLE
Issue 26

### DIFF
--- a/src/modules/db.elasticsearch/client.service.ts
+++ b/src/modules/db.elasticsearch/client.service.ts
@@ -103,6 +103,7 @@ export class ClientService {
     async mGetById(ids: string[], index: string, type: string): Promise<any[]> {
         const params = {
             index,
+            size: ids.length,
             body: {
                 query: {
                     ids: {


### PR DESCRIPTION
Fixes [issue 26](https://github.com/yeg-relief/issue-tracker/issues/26). Now, we return the total number of results discovered. 2 points worth noting:
An elasticsearch max of 10000 results can be returned. 
In the future, we should page between large responses.